### PR TITLE
Add excluded indexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ interactive selection list in the terminal.
   multiple items by hitting SPACE
 - `min_selection_count`: (optional) for multi select feature to
   dictate a minimum of selected items before continuing
+- `excluded_indexes`: (optional) indexes excluded from the selector. Excluded indexes will make it that they wont be able to get selected and just skip over them
 - `screen`: (optional), if you are using `pick` within an existing curses application set this to your existing `screen` object.  It is assumed this has initialised in the standard way (e.g. via `curses.wrapper()`, or `curses.noecho(); curses.cbreak(); screen.kepad(True)`)
 
 ## Community Projects

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -31,7 +31,8 @@ class Picker(Generic[OPTION_T]):
     default_index: int = 0
     multiselect: bool = False
     min_selection_count: int = 0
-    selected_indexes: List[int] = field(init=False, default_factory=list)
+    selected_indexes: List[int] = field(init=False, default_factory=list),
+    excluded_indexes: List[int] = list(),
     index: int = field(init=False, default=0)
     screen: Optional["curses._CursesWindow"] = None
 
@@ -53,11 +54,22 @@ class Picker(Generic[OPTION_T]):
         self.index -= 1
         if self.index < 0:
             self.index = len(self.options) - 1
+        
+        while 1:
+            if self.index not in excludes_indexes: 
+                break
+            self.indexes -= 1
 
     def move_down(self) -> None:
         self.index += 1
         if self.index >= len(self.options):
             self.index = 0
+            
+        while 1:
+            if self.index not in self.excludes_indexes: 
+                break
+            self.indexes += 1
+
 
     def mark_index(self) -> None:
         if self.multiselect:
@@ -187,6 +199,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
+    excluded_indexes: [],
     screen: Optional["curses._CursesWindow"] = None,
 ):
     picker: Picker = Picker(
@@ -196,6 +209,7 @@ def pick(
         default_index,
         multiselect,
         min_selection_count,
+        excluded_indexes,
         screen,
     )
     return picker.start()

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -31,8 +31,8 @@ class Picker(Generic[OPTION_T]):
     default_index: int = 0
     multiselect: bool = False
     min_selection_count: int = 0
-    selected_indexes: List[int] = field(init=False, default_factory=list),
-    excluded_indexes: List[int] = list(),
+    selected_indexes: List[int] = field(init=False, default_factory=list)
+    excluded_indexes: List[int] = field(default_factory=list)
     index: int = field(init=False, default=0)
     screen: Optional["curses._CursesWindow"] = None
 
@@ -58,17 +58,19 @@ class Picker(Generic[OPTION_T]):
         while 1:
             if self.index not in self.excluded_indexes:
                 break
-            self.indexes -= 1
+            self.index -= 1
 
     def move_down(self) -> None:
         self.index += 1
         if self.index >= len(self.options):
             self.index = 0
 
+        import logging
+        logging.info(self.excluded_indexes)
         while 1:
             if self.index not in self.excluded_indexes:
                 break
-            self.indexes += 1
+            self.index += 1
 
     def mark_index(self) -> None:
         if self.multiselect:

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -49,7 +49,7 @@ class Picker(Generic[OPTION_T]):
             )
 
         self.index = self.default_index
-        while self.index not in self.excluded_indexes:
+        while self.index in self.excluded_indexes:
             self.index += 1
 
     def move_up(self) -> None:
@@ -57,7 +57,7 @@ class Picker(Generic[OPTION_T]):
         if self.index < 0:
             self.index = len(self.options) - 1
 
-        while self.index not in self.excluded_indexes:
+        while self.index in self.excluded_indexes:
             self.index += 1
 
     def move_down(self) -> None:
@@ -67,9 +67,9 @@ class Picker(Generic[OPTION_T]):
 
         import logging
         logging.info(self.excluded_indexes)
-        while self.index not in self.excluded_indexes:
+        while self.index in self.excluded_indexes:
             self.index -= 1
-            
+
     def mark_index(self) -> None:
         if self.multiselect:
             if self.index in self.selected_indexes:

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -49,16 +49,16 @@ class Picker(Generic[OPTION_T]):
             )
 
         self.index = self.default_index
+        while self.index not in self.excluded_indexes:
+            self.index += 1
 
     def move_up(self) -> None:
         self.index -= 1
         if self.index < 0:
             self.index = len(self.options) - 1
 
-        while 1:
-            if self.index not in self.excluded_indexes:
-                break
-            self.index -= 1
+        while self.index not in self.excluded_indexes:
+            self.index += 1
 
     def move_down(self) -> None:
         self.index += 1
@@ -67,11 +67,9 @@ class Picker(Generic[OPTION_T]):
 
         import logging
         logging.info(self.excluded_indexes)
-        while 1:
-            if self.index not in self.excluded_indexes:
-                break
-            self.index += 1
-
+        while self.index not in self.excluded_indexes:
+            self.index -= 1
+            
     def mark_index(self) -> None:
         if self.multiselect:
             if self.index in self.selected_indexes:

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -65,8 +65,6 @@ class Picker(Generic[OPTION_T]):
         if self.index >= len(self.options):
             self.index = 0
 
-        import logging
-        logging.info(self.excluded_indexes)
         while self.index in self.excluded_indexes:
             self.index -= 1
 

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -58,7 +58,6 @@ class Picker(Generic[OPTION_T]):
 
         while self.index in self.excluded_indexes:
             self.index -= 1
-        print("Here", self.index)
         if self.index < 0:
             self.index = len(self.options) - 1
 

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -199,7 +199,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    excluded_indexes: [],
+    excluded_indexes = list(),
     screen: Optional["curses._CursesWindow"] = None,
 ):
     picker: Picker = Picker(

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -54,9 +54,9 @@ class Picker(Generic[OPTION_T]):
         self.index -= 1
         if self.index < 0:
             self.index = len(self.options) - 1
-        
+
         while 1:
-            if self.index not in excludes_indexes: 
+            if self.index not in self.excluded_indexes:
                 break
             self.indexes -= 1
 
@@ -64,12 +64,11 @@ class Picker(Generic[OPTION_T]):
         self.index += 1
         if self.index >= len(self.options):
             self.index = 0
-            
+
         while 1:
-            if self.index not in self.excludes_indexes: 
+            if self.index not in self.excluded_indexes:
                 break
             self.indexes += 1
-
 
     def mark_index(self) -> None:
         if self.multiselect:
@@ -138,7 +137,7 @@ class Picker(Generic[OPTION_T]):
         if current_line > max_rows:
             scroll_top = current_line - max_rows
 
-        lines_to_draw = lines[scroll_top : scroll_top + max_rows]
+        lines_to_draw = lines[scroll_top: scroll_top + max_rows]
 
         for line in lines_to_draw:
             screen.addnstr(y, x, line, max_x - 2)

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -52,21 +52,23 @@ class Picker(Generic[OPTION_T]):
         while self.index in self.excluded_indexes:
             self.index += 1
 
+    
     def move_up(self) -> None:
         self.index -= 1
-        if self.index < 0:
-            self.index = len(self.options) - 1
-
-        while self.index in self.excluded_indexes:
-            self.index += 1
-
-    def move_down(self) -> None:
-        self.index += 1
-        if self.index >= len(self.options):
-            self.index = 0
 
         while self.index in self.excluded_indexes:
             self.index -= 1
+        print("Here", self.index)
+        if self.index < 0:
+            self.index = len(self.options) - 1
+
+    def move_down(self) -> None:
+        self.index += 1
+
+        while self.index in self.excluded_indexes:
+            self.index += 1
+        if self.index >= len(self.options):
+            self.index = 0
 
     def mark_index(self) -> None:
         if self.multiselect:

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -196,9 +196,12 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    excluded_indexes = list,
+    excluded_indexes = None,
     screen: Optional["curses._CursesWindow"] = None,
 ):
+    if excluded_indexes is None:
+        excluded_indexes = []
+    
     picker: Picker = Picker(
         options,
         title,

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -196,7 +196,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    excluded_indexes = list(),
+    excluded_indexes = list,
     screen: Optional["curses._CursesWindow"] = None,
 ):
     picker: Picker = Picker(


### PR DESCRIPTION
Added excluded indexes, excluded indexes are put in as a list and will be skipper over when tried to select. 
An user may need this for file selection to make the directories unselectable. 

Code added:
```python
while self.index in self.excluded_indexes:
    self.index -= 1  # - for move_down, and + for move_up
```
