### PR TITLE
Add `clear_screen` parameter

### DIFF
--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -38,6 +38,7 @@ class Picker(Generic[OPTION_T]):
     index: int = field(init=False, default=0)
     screen: Optional["curses._CursesWindow"] = None
     position: Position = Position(0, 0)
+    clear_screen: bool = True
 
     def __post_init__(self) -> None:
         if len(self.options) == 0:
@@ -136,6 +137,9 @@ class Picker(Generic[OPTION_T]):
 
     def draw(self, screen: "curses._CursesWindow") -> None:
         """draw the curses ui on the screen, handle scroll if needed"""
+        if self.clear_screen:
+            screen.clear()
+
         y, x = self.position  # start point
 
         max_y, max_x = screen.getmaxyx()
@@ -226,7 +230,8 @@ def pick(
     multiselect: bool = False,
     min_selection_count: int = 0,
     screen: Optional["curses._CursesWindow"] = None,
-    position: Position = Position(0, 0)
+    position: Position = Position(0, 0),
+    clear_screen = True,
 ):
     picker: Picker = Picker(
         options,
@@ -237,5 +242,6 @@ def pick(
         min_selection_count,
         screen,
         position,
+        clear_screen,
     )
     return picker.start()


### PR DESCRIPTION
In #95 we added a `position` parameter to allow users to specify the position to show the options. And we didn't call `screen.clear()` with that change. But in some use cases, like #123, users do expect that the screen should be cleared.

At first, I thought we could use `None` as the default value for the `position` parameter and in this case, we could call `screen.clear()`. But then I realized that the `position` argument shouldn't be coupled with whether we should call `screen.clear()`. Someone might just want to show the options in the middle of the screen, and they still want the screen to be cleared.

So I decided to add a new parameter `clear_screen` to change the behavior, and the default value for `clear_screen` is `True` to maintain compatibility.

@Cornelius-Figgle, does this satisfy your original requirements?