### PR TITLE
feat(picker): support negative default_index

### DIFF
--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -66,8 +66,11 @@ class Picker(Generic[OPTION_T]):
         if len(self.options) == 0:
             raise ValueError("options should not be an empty list")
 
-        if self.default_index >= len(self.options):
-            raise ValueError("default_index should be less than the length of options")
+        if self.default_index < -len(self.options) or self.default_index >= len(self.options):
+            raise ValueError("default_index is out of range of options")
+
+        if self.default_index < 0:
+            self.default_index += len(self.options)
 
         if self.multiselect and self.min_selection_count > len(self.options):
             raise ValueError(

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -77,3 +77,21 @@ def test_disabled_option():
     assert picker.get_selected() == (Option("option1"), 0)
     picker.move_down()
     assert picker.get_selected() == (Option("option3"), 2)
+
+
+def test_negative_default_index():
+    import pytest
+    options = ["option1", "option2", "option3"]
+    picker = Picker(options, default_index=-1)
+    assert picker.get_selected() == ("option3", 2)
+    lines, _ = picker.get_lines()
+    assert "* option3" in lines
+
+    picker = Picker(options, default_index=-3)
+    assert picker.get_selected() == ("option1", 0)
+
+    with pytest.raises(ValueError):
+        Picker(options, default_index=-4)
+    with pytest.raises(ValueError):
+        Picker(options, default_index=3)
+

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -1,4 +1,6 @@
-from pick import Picker, Option
+import pytest
+
+from pick import Option, Picker
 
 
 def test_move_up_down():
@@ -80,7 +82,6 @@ def test_disabled_option():
 
 
 def test_negative_default_index():
-    import pytest
     options = ["option1", "option2", "option3"]
     picker = Picker(options, default_index=-1)
     assert picker.get_selected() == ("option3", 2)
@@ -94,4 +95,3 @@ def test_negative_default_index():
         Picker(options, default_index=-4)
     with pytest.raises(ValueError):
         Picker(options, default_index=3)
-


### PR DESCRIPTION
## Summary

This PR adds support for negative `default_index` values (e.g. `default_index=-1` to select the last option by default), following standard Python negative indexing conventions.

- Bounds checking ensures `-len(options) <= default_index < len(options)`.
- Negative indices are converted to their corresponding positive index upon initialization.
- Added comprehensive unit tests in `tests/test_pick.py`.

## Testing
- Ran pytest test suite with all tests passing.
- Ran mypy type checks with 0 errors.