### PR TITLE
fix(picker): prevent marking disabled options in mark_index

### DIFF
--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -104,6 +104,9 @@ class Picker(Generic[OPTION_T]):
 
     def mark_index(self) -> None:
         if self.multiselect:
+            option = self.options[self.index]
+            if isinstance(option, Option) and not option.enabled:
+                return
             if self.index in self.selected_indexes:
                 self.selected_indexes.remove(self.index)
             else:

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -85,4 +85,3 @@ def test_mark_index_disabled_option():
     picker.index = 1  # Point directly to disabled option2
     picker.mark_index()
     assert picker.get_selected() == []  # Disabled option should NOT be marked
-

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -77,3 +77,12 @@ def test_disabled_option():
     assert picker.get_selected() == (Option("option1"), 0)
     picker.move_down()
     assert picker.get_selected() == (Option("option3"), 2)
+
+
+def test_mark_index_disabled_option():
+    options = [Option("option1"), Option("option2", enabled=False), Option("option3")]
+    picker = Picker(options, multiselect=True)
+    picker.index = 1  # Point directly to disabled option2
+    picker.mark_index()
+    assert picker.get_selected() == []  # Disabled option should NOT be marked
+


### PR DESCRIPTION
## Summary

When `multiselect=True`, invoking `mark_index()` (either directly or via custom keybindings) could toggle the selection status of a disabled option.

This PR adds an explicit guard in `Picker.mark_index()` to ignore disabled options (`Option(..., enabled=False)`), preventing them from being added to `selected_indexes`.

## Testing
- Added unit test `test_mark_index_disabled_option` in `tests/test_pick.py`.
- Ran full pytest test suite (all passing).
- Ran mypy type checks (clean).