### PR TITLE
feat(picker): add select_all and deselect_all methods and interactive keybindings

### DIFF
--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -112,6 +112,21 @@ class Picker(Generic[OPTION_T]):
             else:
                 self.selected_indexes.append(self.index)
 
+    def select_all(self) -> None:
+        """Select all enabled options in multiselect mode."""
+        if not self.multiselect:
+            return
+        self.selected_indexes = [
+            i for i, option in enumerate(self.options)
+            if not isinstance(option, Option) or option.enabled
+        ]
+
+    def deselect_all(self) -> None:
+        """Deselect all options in multiselect mode."""
+        if not self.multiselect:
+            return
+        self.selected_indexes.clear()
+
     def get_selected(self) -> Union[List[PICK_RETURN_T], PICK_RETURN_T]:
         """return the current selected option as a tuple: (option, index)
         or as a list of tuples (in case multiselect==True)

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -36,6 +36,8 @@ KEYS_ENTER = (curses.KEY_ENTER, ord("\n"), ord("\r"))
 KEYS_UP = (curses.KEY_UP, ord("k"))
 KEYS_DOWN = (curses.KEY_DOWN, ord("j"))
 KEYS_SELECT = (curses.KEY_RIGHT, ord(" "))
+KEYS_SELECT_ALL = (ord("a"),)
+KEYS_DESELECT_ALL = (ord("d"),)
 
 SYMBOL_CIRCLE_FILLED = "(x)"
 SYMBOL_CIRCLE_EMPTY = "( )"
@@ -244,6 +246,10 @@ class Picker(Generic[OPTION_T]):
                 return self.get_selected()
             elif c in KEYS_SELECT and self.multiselect:
                 self.mark_index()
+            elif c in KEYS_SELECT_ALL and self.multiselect:
+                self.select_all()
+            elif c in KEYS_DESELECT_ALL and self.multiselect:
+                self.deselect_all()
 
     def _resolve_backend(self) -> Backend:
         if isinstance(self.backend, Backend):

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -85,3 +85,13 @@ def test_mark_index_disabled_option():
     picker.index = 1  # Point directly to disabled option2
     picker.mark_index()
     assert picker.get_selected() == []  # Disabled option should NOT be marked
+
+
+def test_select_all_and_deselect_all():
+    options = [Option("option1"), Option("option2", enabled=False), Option("option3")]
+    picker = Picker(options, multiselect=True)
+    picker.select_all()
+    # Should only select option1 (0) and option3 (2), ignoring disabled option2 (1)
+    assert picker.get_selected() == [(Option("option1"), 0), (Option("option3"), 2)]
+    picker.deselect_all()
+    assert picker.get_selected() == []


### PR DESCRIPTION
## Summary

Adds `select_all()` and `deselect_all()` helper methods and interactive keybindings to `Picker` for multiselect mode:

- `Picker.select_all()`: Selects all available options that are enabled (`Option.enabled is not False`).
- `Picker.deselect_all()`: Clears `selected_indexes`.
- Both methods safely return immediately if `multiselect=False`.
- Added interactive keybindings in `Picker.run_loop`:
  - `a` (`KEYS_SELECT_ALL`): Triggers `select_all()`.
  - `d` (`KEYS_DESELECT_ALL`): Triggers `deselect_all()`.

## Testing
- Added unit test `test_select_all_and_deselect_all` in `tests/test_pick.py`.
- Ran full pytest test suite (all passing).
- Ran mypy type checks (clean).